### PR TITLE
Balance de sumas y saldos filtrando por diario

### DIFF
--- a/account_financial_report/report/templates/trial_balance.xml
+++ b/account_financial_report/report/templates/trial_balance.xml
@@ -247,6 +247,9 @@
                         <t t-set="domain"
                            t-value="[('account_id', '=', line.account_id.id),
                                      ('date', '&lt;', o.date_from)]"/>
+                        <t t-if="o.filter_journal_ids">
+                             <t t-set="domain" t-value="o.get_extra_domain(domain)"/>
+                        </t>
                         <span>
                             <a t-att-data-domain="domain"
                                t-att-data-res-model="'account.move.line'"
@@ -259,6 +262,9 @@
                         <t t-set="domain"
                            t-value="[('account_id', 'in', line.compute_account_ids.ids),
                                      ('date', '&lt;', o.date_from)]"/>
+                        <t t-if="o.filter_journal_ids">
+                            <t t-set="domain" t-value="o.get_extra_domain(domain)"/>
+                        </t>
                         <span>
                             <a t-att-data-domain="domain"
                                t-att-data-res-model="'account.move.line'"
@@ -273,6 +279,9 @@
                        t-value="[('account_id', '=', line.report_account_id.account_id.id),
                                  ('partner_id', '=', line.partner_id.id),
                                  ('date', '&lt;', o.date_from)]"/>
+                    <t t-if="o.filter_journal_ids">
+                        <t t-set="domain" t-value="o.get_extra_domain(domain)"/>
+                    </t>
                     <span>
                         <a t-att-data-domain="domain"
                            t-att-data-res-model="'account.move.line'"
@@ -291,6 +300,9 @@
                                      ('date', '&gt;=', line.report_id.date_from),
                                      ('date', '&lt;=', line.report_id.date_to),
                                      ('debit', '&lt;&gt;', 0)]"/>
+                        <t t-if="o.filter_journal_ids">
+                            <t t-set="domain" t-value="o.get_extra_domain(domain)"/>
+                        </t>
                         <span>
                             <a t-att-data-domain="domain"
                                t-att-data-res-model="'account.move.line'"
@@ -305,6 +317,9 @@
                                      ('date', '&gt;=', line.report_id.date_from),
                                      ('date', '&lt;=', line.report_id.date_to),
                                      ('debit', '&lt;&gt;', 0)]"/>
+                        <t t-if="o.filter_journal_ids">
+                            <t t-set="domain" t-value="o.get_extra_domain(domain)"/>
+                        </t>
                         <span>
                             <a t-att-data-domain="domain"
                                t-att-data-res-model="'account.move.line'"
@@ -321,6 +336,9 @@
                                  ('date', '&gt;=', line.report_account_id.report_id.date_from),
                                  ('date', '&lt;=', line.report_account_id.report_id.date_to),
                                  ('debit', '&lt;&gt;', 0)]"/>
+                    <t t-if="o.filter_journal_ids">
+                        <t t-set="domain" t-value="o.get_extra_domain(domain)"/>
+                    </t>
                     <span>
                         <a t-att-data-domain="domain"
                            t-att-data-res-model="'account.move.line'"
@@ -339,6 +357,9 @@
                                      ('date', '&gt;=', line.report_id.date_from),
                                      ('date', '&lt;=', line.report_id.date_to),
                                      ('credit', '&lt;&gt;', 0)]"/>
+                        <t t-if="o.filter_journal_ids">
+                           <t t-set="domain" t-value="o.get_extra_domain(domain)"/>
+                        </t>
                         <span>
                             <a t-att-data-domain="domain"
                                t-att-data-res-model="'account.move.line'"
@@ -353,6 +374,9 @@
                                      ('date', '&gt;=', line.report_id.date_from),
                                      ('date', '&lt;=', line.report_id.date_to),
                                      ('credit', '&lt;&gt;', 0)]"/>
+                        <t t-if="o.filter_journal_ids">
+                            <t t-set="domain" t-value="o.get_extra_domain(domain)"/>
+                        </t>
                         <span>
                             <a t-att-data-domain="domain"
                                t-att-data-res-model="'account.move.line'"
@@ -369,6 +393,9 @@
                                  ('date', '&gt;=', line.report_account_id.report_id.date_from),
                                  ('date', '&lt;=', line.report_account_id.report_id.date_to),
                                  ('credit', '&lt;&gt;', 0)]"/>
+                        <t t-if="o.filter_journal_ids">
+                            <t t-set="domain" t-value="o.get_extra_domain(domain)"/>
+                        </t>
                     <span>
                         <a t-att-data-domain="domain"
                            t-att-data-res-model="'account.move.line'"
@@ -386,6 +413,9 @@
                            t-value="[('account_id', '=', line.account_id.id),
                                      ('date', '&gt;=', line.report_id.date_from),
                                      ('date', '&lt;=', line.report_id.date_to)]"/>
+                        <t t-if="o.filter_journal_ids">
+                           <t t-set="domain" t-value="o.get_extra_domain(domain)"/>
+                        </t>
                         <span>
                             <a t-att-data-domain="domain"
                                t-att-data-res-model="'account.move.line'"
@@ -399,6 +429,9 @@
                            t-value="[('account_id', 'in', line.compute_account_ids.ids),
                                      ('date', '&gt;=', line.report_id.date_from),
                                      ('date', '&lt;=', line.report_id.date_to)]"/>
+                        <t t-if="o.filter_journal_ids">
+                           <t t-set="domain" t-value="o.get_extra_domain(domain)"/>
+                        </t>
                         <span>
                             <a t-att-data-domain="domain"
                                t-att-data-res-model="'account.move.line'"
@@ -414,6 +447,9 @@
                                  ('partner_id', '=', line.partner_id.id),
                                  ('date', '&gt;=', line.report_account_id.report_id.date_from),
                                  ('date', '&lt;=', line.report_account_id.report_id.date_to)]"/>
+                    <t t-if="o.filter_journal_ids">
+                       <t t-set="domain" t-value="o.get_extra_domain(domain)"/>
+                    </t>
                     <span>
                         <a t-att-data-domain="domain"
                            t-att-data-res-model="'account.move.line'"
@@ -429,6 +465,9 @@
                     <t t-if="line.account_id">
                         <t t-set="domain"
                            t-value="[('account_id', '=', line.account_id.id)]"/>
+                        <t t-if="o.filter_journal_ids">
+                           <t t-set="domain" t-value="o.get_extra_domain(domain)"/>
+                        </t>
                         <span>
                             <a t-att-data-domain="domain"
                                t-att-data-res-model="'account.move.line'"
@@ -440,6 +479,9 @@
                     <t t-if="line.account_group_id">
                         <t t-set="domain"
                            t-value="[('account_id', 'in', line.compute_account_ids.ids)]"/>
+                        <t t-if="o.filter_journal_ids">
+                           <t t-set="domain" t-value="o.get_extra_domain(domain)"/>
+                        </t>
                         <span>
                             <a t-att-data-domain="domain"
                                t-att-data-res-model="'account.move.line'"
@@ -453,6 +495,9 @@
                     <t t-set="domain"
                        t-value="[('account_id', '=', line.report_account_id.account_id.id),
                                  ('partner_id', '=', line.partner_id.id)]"/>
+                    <t t-if="o.filter_journal_ids">
+                        <t t-set="domain" t-value="o.get_extra_domain(domain)"/>
+                    </t>
                     <span>
                         <a t-att-data-domain="domain"
                            t-att-data-res-model="'account.move.line'"
@@ -474,6 +519,9 @@
                             <t t-if="line.account_id">
                                 <t t-set="domain"
                                    t-value="[('account_id', '=', line.account_id.id)]"/>
+                                <t t-if="o.filter_journal_ids">
+                                    <t t-set="domain" t-value="o.get_extra_domain(domain)"/>
+                                </t>
                                 <span>
                                     <a t-att-data-domain="domain"
                                        t-att-data-res-model="'account.move.line'"
@@ -485,6 +533,9 @@
                             <t t-if="line.account_group_id">
                                 <t t-set="domain"
                                    t-value="[('account_id', 'in', line.compute_account_ids.ids)]"/>
+                                <t t-if="o.filter_journal_ids">
+                                   <t t-set="domain" t-value="o.get_extra_domain(domain)"/>
+                                </t>
                                 <span>
                                     <a t-att-data-domain="domain"
                                        t-att-data-res-model="'account.move.line'"
@@ -498,6 +549,9 @@
                             <t t-set="domain"
                                t-value="[('account_id', '=', line.report_account_id.account_id.id),
                                          ('partner_id', '=', line.partner_id.id)]"/>
+                            <t t-if="o.filter_journal_ids">
+                                <t t-set="domain" t-value="o.get_extra_domain(domain)"/>
+                            </t>
                             <span>
                                 <a t-att-data-domain="domain"
                                    t-att-data-res-model="'account.move.line'"
@@ -513,6 +567,9 @@
                             <t t-if="line.account_id">
                                 <t t-set="domain"
                                    t-value="[('account_id', '=', line.account_id.id)]"/>
+                                <t t-if="o.filter_journal_ids">
+                                   <t t-set="domain" t-value="o.get_extra_domain(domain)"/>
+                                </t>
                                 <span>
                                     <a t-att-data-domain="domain"
                                        t-att-data-res-model="'account.move.line'"
@@ -524,6 +581,9 @@
                             <t t-if="line.account_group_id">
                                 <t t-set="domain"
                                    t-value="[('account_id', 'in', line.compute_account_ids.ids)]"/>
+                                <t t-if="o.filter_journal_ids">
+                                   <t t-set="domain" t-value="o.get_extra_domain(domain)"/>
+                                </t>
                                 <span>
                                     <a t-att-data-domain="domain"
                                        t-att-data-res-model="'account.move.line'"
@@ -537,6 +597,9 @@
                             <t t-set="domain"
                                t-value="[('account_id', '=', line.report_account_id.account_id.id),
                                          ('partner_id', '=', line.partner_id.id)]"/>
+                            <t t-if="o.filter_journal_ids">
+                               <t t-set="domain" t-value="o.get_extra_domain(domain)"/>
+                            </t>
                             <span>
                                 <a t-att-data-domain="domain"
                                    t-att-data-res-model="'account.move.line'"
@@ -577,6 +640,9 @@
                     <t t-set="domain"
                         t-value="[('account_id', '=', account.account_id.id),
                                   ('date', '&lt;', o.date_from)]"/>
+                    <t t-if="o.filter_journal_ids">
+                        <t t-set="domain" t-value="o.get_extra_domain(domain)"/>
+                    </t>
                     <span>
                         <a t-att-data-domain="domain"
                            t-att-data-res-model="'account.move.line'"
@@ -592,6 +658,9 @@
                                   ('date', '&gt;=', account.report_id.date_from),
                                   ('date', '&lt;=', account.report_id.date_to),
                                   ('debit', '&lt;&gt;', 0)]"/>
+                    <t t-if="o.filter_journal_ids">
+                        <t t-set="domain" t-value="o.get_extra_domain(domain)"/>
+                    </t>
                     <span>
                         <a t-att-data-domain="domain"
                            t-att-data-res-model="'account.move.line'"
@@ -607,6 +676,9 @@
                                   ('date', '&gt;=', account.report_id.date_from),
                                   ('date', '&lt;=', account.report_id.date_to),
                                   ('credit', '&lt;&gt;', 0)]"/>
+                    <t t-if="o.filter_journal_ids">
+                        <t t-set="domain" t-value="o.get_extra_domain(domain)"/>
+                    </t>
                     <span>
                         <a t-att-data-domain="domain"
                            t-att-data-res-model="'account.move.line'"
@@ -622,6 +694,9 @@
                                   ('date', '&gt;=', account.report_id.date_from),
                                   ('date', '&lt;=', account.report_id.date_to),
                                   ('period_balance', '&lt;&gt;', 0)]"/>
+                    <t t-if="o.filter_journal_ids">
+                       <t t-set="domain" t-value="o.get_extra_domain(domain)"/>
+                    </t>
                     <span>
                         <a t-att-data-domain="domain"
                            t-att-data-res-model="'account.move.line'"
@@ -634,6 +709,9 @@
                 <div class="act_as_cell amount" style="width: 9.64%;">
                     <t t-set="domain"
                            t-value="[('account_id', '=', account.account_id.id)]"/>
+                    <t t-if="o.filter_journal_ids">
+                       <t t-set="domain" t-value="o.get_extra_domain(domain)"/>
+                    </t>
                     <span>
                         <a t-att-data-domain="domain"
                            t-att-data-res-model="'account.move.line'"
@@ -648,6 +726,9 @@
                         <div class="act_as_cell" style="width: 4.43%;">
                             <t t-set="domain"
                             t-value="[('account_id', '=', account.account_id.id)]"/>
+                            <t t-if="o.filter_journal_ids">
+                                <t t-set="domain" t-value="o.get_extra_domain(domain)"/>
+                            </t>
                             <span t-field="account.currency_id.display_name"/>
                         </div>
                         <!--## balance_currency-->
@@ -655,6 +736,9 @@
                             <t t-set="domain"
                             t-value="[('account_id', '=', account.account_id.id),
                                       ('date', '&lt;', o.date_from)]"/>
+                            <t t-if="o.filter_journal_ids">
+                                <t t-set="domain" t-value="o.get_extra_domain(domain)"/>
+                            </t>
                             <span>
                                 <a t-att-data-domain="domain"
                                    t-att-data-res-model="'account.move.line'"
@@ -666,6 +750,9 @@
                         <div class="act_as_cell amount" style="width: 8.86%;">
                             <t t-set="domain"
                                t-value="[('account_id', '=', account.account_id.id)]"/>
+                            <t t-if="o.filter_journal_ids">
+                                <t t-set="domain" t-value="o.get_extra_domain(domain)"/>
+                            </t>
                             <span>
                                 <a t-att-data-domain="domain"
                                    t-att-data-res-model="'account.move.line'"

--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -62,6 +62,13 @@ class TrialBalanceReport(models.TransientModel):
         inverse_name='report_id'
     )
 
+    @api.model
+    def get_extra_domain(self, domain):
+        if self.filter_journal_ids:
+            domain.extend(
+                [('journal_id', 'in', self.filter_journal_ids.ids)])
+        return domain
+
 
 class TrialBalanceReportAccount(models.TransientModel):
     _name = 'report_trial_balance_account'


### PR DESCRIPTION
Un balance de sumas y saldos filtrando por diario no tiene mucho sentido, pero hay gente en el mundo que lo quiere... El asistente del informe incorpora un filtro por diarios pero luego no se utiliza para nada. Hago estas modificaciones para hacer ese filtro funcional y en caso de que lo utilicen, que los datos que se generen sean los de el/los diarios seleccionados.